### PR TITLE
BUGFIX: Adjust afx-dependency to properly support Neos 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "neos/neos": "^3.3 || ^4.0 || dev-master",
         "neos/neos-ui": "^2.2 || ^3.2 || dev-master",
         "neos/seo": "^2.1 || ^3.0",
-        "neos/fusion-afx": "^1.2"
+        "neos/fusion-afx": ">1.1"
     },
     "replace": {
         "shel/neos-yoast-seo": "self.version"


### PR DESCRIPTION
AFX in version 1.2 is not available for Neos 3.3 since it needs the fusion spreads that were introduced in Neos 4.2. Since neither @apply nor afx spreads are used the dependency can be relaxed to properly work with Neos 3.3 and UI 2.2+