### PR TITLE
BUGFIX: Use correct version constraint for Neos 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "neos/neos": "^3.3 || ^4.0 || dev-master",
         "neos/neos-ui": "^2.2 || ^3.2 || dev-master",
         "neos/seo": "^2.1 || ^3.0",
-        "neos/fusion-afx": ">1.1"
+        "neos/fusion-afx": ">=1.1"
     },
     "replace": {
         "shel/neos-yoast-seo": "self.version"


### PR DESCRIPTION
Sadly my previous adjustment was as wrong as the situation before as it still excluded the 1.1 version.