### PR TITLE
README: Fix typo in Ui-config-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ and
 
     Neos:
       Neos:
-        UI:    
+        Ui:    
           frontendConfiguration:
             'Yoast.YoastSeoForNeos':
                contentSelector: 'body'


### PR DESCRIPTION
Found a typo in the readme: The config key `Ui` was typed as `UI`