### PR TITLE
Replace deprecated aloha config with editorOptions

### DIFF
--- a/Configuration/NodeTypes.Mixin.SEO.yaml
+++ b/Configuration/NodeTypes.Mixin.SEO.yaml
@@ -9,9 +9,9 @@
         label: i18n
         inlineEditable: true
         reloadIfChanged: true
-        aloha:
-          placeholder: i18n
         inspector:
+          editorOptions:
+            placeholder: i18n
           group: yoast
           position: 10
     isCornerstone:


### PR DESCRIPTION
The aloha configuration [was removed in Neos 7.0](https://www.neos.io/blog/seven-up-neos-7-flow-7-released.html#neos-7-further-changes), using it in this package doesn't seem to break anything aside from not having a placeholder, but an error is thrown in the `configuration:validate` process.
The i18n value isn't correctly replaced and it will display "i18n" as a placeholder. However, that seems to be a bug/issue in Neos (See https://github.com/neos/neos-development-collection/issues/3249).