### PR TITLE
FIX: Default Locale and language file for en

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,11 +1,11 @@
 Yoast:
   YoastSeoForNeos:
     devMode: false
-    defaultContentLocale: en-US
+    defaultContentLocale: en_GB
     languageToLocaleMapping:
       da: 'da_DK'
       de: 'de_DE-formal'
-      en: ''
+      en: 'en_GB'
       es: 'es_ES'
       fi: 'fi'
       fr: 'fr_FR'


### PR DESCRIPTION
Since there is no language file present for locale en-US this uses en_GB by default